### PR TITLE
Add Wayland support flags to .desktop file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,12 @@ desktop_terminal=false
 desktop_type=Application
 desktop_categories="Api;JSON;HTTP;Request;Web;Rest;API Client;"
 desktop_startup_wm_class="Apidog"
-desktop_exec="$executable_path %u"
+
+if [ "$XDG_SESSION_TYPE" = "wayland" ] || [ "$WAYLAND_DISPLAY" != "" ]; then
+  desktop_exec="$executable_path --enable-features=UseOzonePlatform --ozone-platform=wayland %u"
+else
+  desktop_exec="$executable_path %u"
+fi
 
 echo "Welcome to $display_name tarball installer, just chill and wait for the installation to complete!"
 


### PR DESCRIPTION
Automatically detects Wayland sessions and applies the necessary Electron flags (`--enable-features=UseOzonePlatform --ozone-platform=wayland`) to ensure Apidog runs properly on modern Linux distributions.

- Added automatic Wayland session detection via `$XDG_SESSION_TYPE` and `$WAYLAND_DISPLAY`
- Conditionally applies Wayland-specific flags only when needed
- Maintains full backward compatibility with X11 sessions

- ✅ Tested on Fedora (Wayland session)
- ✅ Verified X11 compatibility unchanged

Fixes rendering and input issues on Wayland while preserving existing X11 functionality.